### PR TITLE
Fix: Schedule Card Layout

### DIFF
--- a/resources/views/animes/schedule.blade.php
+++ b/resources/views/animes/schedule.blade.php
@@ -46,7 +46,7 @@
                     @endif
                 </a>
                 <div class="relative flex flex-col w-3/5 gap-1 px-2 pt-2">
-                    <div class="flex flex-col gap-1 text-sm xl:text-base">
+                    <div class=" gap-1 text-sm xl:text-base">
                         <div x-data="{ title: `{{ $anime['title'] }}` }" class="flex">
                             <a
                                 href="{{ route('anime.show', $anime['mal_id']) }}"
@@ -89,14 +89,14 @@
                         </div>
                     </div>
                     <div class="absolute inset-x-0 bottom-0 flex gap-1 p-2 md:flex-col lg:flex-row">
-                        <div class="flex flex-row flex-wrap items-center justify-center gap-3 p-1 bg-gray-200 bg-opacity-80 dark:bg-gray-900 dark:bg-opacity-60">
+                        <div class="flex flex-row flex-wrap items-center justify-center gap-3 p-1 px-2 bg-gray-200 bg-opacity-80 dark:bg-gray-900 dark:bg-opacity-60 rounded-lg ">
                             @forelse ($resources[$anime['mal_id']] as $resource)
                             <a href="{{ $resource->link }}" target="_blank" class="w-6 h-6 lg:w-7 lg:h-7" title="{{ $resource->alternative_note }}">
                                 <img src="{{ logo_asset($resource->platform->icon_path) }}" alt="{{ $resource->platform->name }} Logo" />
                             </a>
                             @empty
                             <x-icons.x class="w-6 h-6 lg:w-7 lg:h-7" />
-                            <span class="text-sm lg:text-md">{{ __('anime.single.availability_empty_short') }}</span>
+                            <span class="text-sm lg:text-md px-2">{{ __('anime.single.availability_empty_short') }}</span>
                             @endforelse
                         </div>
                     </div>

--- a/resources/views/animes/schedule.blade.php
+++ b/resources/views/animes/schedule.blade.php
@@ -46,7 +46,7 @@
                     @endif
                 </a>
                 <div class="relative flex flex-col w-3/5 gap-1 px-2 pt-2">
-                    <div class=" gap-1 text-sm xl:text-base">
+                    <div class="gap-1 text-sm xl:text-base">
                         <div x-data="{ title: `{{ $anime['title'] }}` }" class="flex">
                             <a
                                 href="{{ route('anime.show', $anime['mal_id']) }}"
@@ -89,7 +89,7 @@
                         </div>
                     </div>
                     <div class="absolute inset-x-0 bottom-0 flex gap-1 p-2 md:flex-col lg:flex-row">
-                        <div class="flex flex-row flex-wrap items-center justify-center gap-3 p-1 px-2 bg-gray-200 bg-opacity-80 dark:bg-gray-900 dark:bg-opacity-60 rounded-lg ">
+                        <div class="flex flex-row flex-wrap items-center justify-center gap-3 px-2 py-1 rounded-lg bg-gray-200 bg-opacity-80 dark:bg-gray-900 dark:bg-opacity-60">
                             @forelse ($resources[$anime['mal_id']] as $resource)
                             <a href="{{ $resource->link }}" target="_blank" class="w-6 h-6 lg:w-7 lg:h-7" title="{{ $resource->alternative_note }}">
                                 <img src="{{ logo_asset($resource->platform->icon_path) }}" alt="{{ $resource->platform->name }} Logo" />


### PR DESCRIPTION
Fixing platform bg overlap other component on xl // Alternative: size down anime title (especially 2 line anime titles) size on xl > https://i.imgur.com/qvjEi36.png add rounded on platform and add horizontal padding (especially "Tidak tersedia") for better look